### PR TITLE
Add separator metadata to first line of CSV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ build-iPhoneSimulator/
 *.iml
 .idea/
 .travis.yml
+.byebug_history

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,12 @@
 PATH
   remote: .
   specs:
-    csv_composer (1.0.2)
+    csv_composer (1.0.3)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    byebug (11.0.1)
     minitest (5.10.3)
     rake (10.5.0)
 
@@ -14,9 +15,10 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.14)
+  byebug
   csv_composer!
   minitest (~> 5.0)
   rake (~> 10.0)
 
 BUNDLED WITH
-   1.16.0
+   1.17.2

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ both header and item processor that you can use when overriding them.
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `bundle exec rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/csv_composer.gemspec
+++ b/csv_composer.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "byebug"
 end

--- a/lib/csv_composer/base.rb
+++ b/lib/csv_composer/base.rb
@@ -2,7 +2,9 @@ module CsvComposer
   class Base
 
     def compose(items, opts = {})
-      content = write(items, opts)
+      content = separator_metadata
+      content += write(items, opts)
+
       export(content, opts)
     end
 
@@ -28,6 +30,10 @@ module CsvComposer
 
     def export(content, opts = {})
       exporter.new.export(content, opts)
+    end
+    
+    def separator_metadata
+      "sep=,\n"
     end
 
   end

--- a/test/generic_test.rb
+++ b/test/generic_test.rb
@@ -15,6 +15,8 @@ module CsvComposer
     def test_returns_csv_content_in_memory_file_with_original_filename_associated
       filename = 'filename'
       file = @exporter.compose(@items, filename: filename)
+
+      assert(file.string.start_with?('sep=,\n'))
       assert_equal(file.original_filename, filename)
       assert_equal(file.class, StringIO)
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require 'csv_composer'
 require 'minitest/autorun'
+require 'byebug'

--- a/test/writer_test.rb
+++ b/test/writer_test.rb
@@ -53,5 +53,5 @@ module CsvComposer
       assert_equal(expected_content, content)
       assert_mock(item_processor)
     end
-end
+  end
 end


### PR DESCRIPTION
This PR adds `sep=,` as the first line of the generated CSV content.
This is used to explicitly let Excel know what separator is used in the file.
See: https://stackoverflow.com/a/40720116/889345